### PR TITLE
Fix browserid locator

### DIFF
--- a/pages/start_page.py
+++ b/pages/start_page.py
@@ -23,8 +23,7 @@ class StartPage(Page):
     _facebook_button_locator = (By.CSS_SELECTOR, '.button.share_facebook')
 
     #Not LoggedIn
-    _login_browser_id_locator = (By.CSS_SELECTOR, '.browserid-button:nth-of-type(1) a')
-    _register_browser_id_locator = (By.CSS_SELECTOR, '.browserid-button:nth-of-type(2) a')
+    _login_browser_id_locator = (By.CSS_SELECTOR, 'a.persona-button')
 
     def __init__(self, testsetup, open_url=True):
         ''' Creates a new instance of the class and gets the page ready for testing '''


### PR DESCRIPTION
This fixes the failures on dev (affiliates.trunk and affiliates.truck.saucelabs) related to the browserid locator.

Note that merging this will cause the tests to fail on stage and prod. I'm not sure if the problem is that dev is inaccurate because it is out of sync with stage/prod, or that the change hasn't been pushed yet to stage/prod from dev.

What is the best way to deal with changes like this, that cause tests to fail on one platform but not others? Conditionally xfailing seems like a lot of work/maintenance.
