### PR TITLE
Change size select locator to address Selenium click issue

### DIFF
--- a/pages/home.py
+++ b/pages/home.py
@@ -31,7 +31,7 @@ class Home(Page):
     _banner_size_locator = (By.CSS_SELECTOR, '#uniform-size.selector span')
     _banner_preview_locator = (By.ID, 'banner_preview')
     _step_buttons_locator = (By.CSS_SELECTOR, '.steps-buttons')
-    _size_selector_locator = (By.ID, 'size')
+    _size_selector_locator = (By.ID, 'uniform-size')
     _color_selector_locator = (By.ID, 'color')
     _language_selector_locator = (By.ID, 'language')
 


### PR DESCRIPTION
When testing Affiliates-Tests with the latest Selenium I was having issues with the code in this page object. Selenium seemed to fail at clicking the size option at https://github.com/bobsilverberg/Affiliates-Tests/blob/57d83da6652078ae6707c113be3c2da8eaafa637/pages/home.py#L82. Although this issue was new with Se 2.35, it also seems to be related to some funky css in the page and I was not able to reliably create a reduced replicable test case for it.

The problem was occurring intermittently in my testing. 

This change to the parent locator fixed the issue for me. I suggest we hold off on this pull request until we see whether CI had issues with the test after we upgrade to Se 2.35.  If we don't see any issues, we can close this pull request.
