### PR TITLE
Fixed failing tests for wrong reason

### DIFF
--- a/pages/start_page.py
+++ b/pages/start_page.py
@@ -6,6 +6,7 @@
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.support.ui import WebDriverWait
 
 from page import Page
 
@@ -66,6 +67,8 @@ class StartPage(Page):
     def hover_over_learn_more_link(self):
         learn_more = self.selenium.find_element(*self._learn_more_link_locator)
         ActionChains(self.selenium).move_to_element(learn_more).perform()
+        WebDriverWait(self.selenium, self.timeout).until(
+                lambda s: s.find_element(*self._learn_more_tooltip_locator).get_attribute('style') == "display: block;")
 
     @property
     def is_learn_more_tooltip_visible(self):

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -17,8 +17,6 @@ class TestHomePage:
 
     @nondestructive
     def test_edit_profile_has_proper_display_name(self, mozwebqa):
-        if mozwebqa.base_url == 'https://affiliates-dev.allizom.org':
-            pytest.xfail(reason='Bug 897575 - [dev][traceback] Unable to register new accounts')
         start_page = StartPage(mozwebqa)
         home_page = start_page.login()
         username = mozwebqa.credentials['default']['name']

--- a/tests/test_start_page.py
+++ b/tests/test_start_page.py
@@ -37,7 +37,6 @@ class TestStartPage:
         Assert.true(start_page.is_twitter_button_present)
         Assert.true(start_page.is_facebook_button_present)
 
-    @pytest.mark.xfail(reason='Selenium visibility/scroll issue, see http://code.google.com/p/selenium/issues/detail?id=6105')
     @nondestructive
     def test_that_text_bubble_appears_on_hovering_learn_more_link(self, mozwebqa):
         start_page = StartPage(mozwebqa)


### PR DESCRIPTION
http://qa-selenium.mv.mozilla.com:8080/view/Affiliates/job/affiliates.trunk/lastCompletedBuild/HTML_Report/?
Fixed test that was failing for wrong reason and removed xfail
