### PR TITLE
Fix locator for test_edit_profile_has_proper_display_name

### DIFF
--- a/pages/user.py
+++ b/pages/user.py
@@ -22,6 +22,7 @@ class EditProfile(Page):
 
         _modal_locator = (By.CSS_SELECTOR, '#profile > div#modal')
 
+        _display_name_locator = (By.ID, 'id_display_name')
         _save_locator = (By.CSS_SELECTOR, '.button.go')
         _cancel_locator = (By.CSS_SELECTOR, '.button.close')
 


### PR DESCRIPTION
Context - we're refactoring the entire suite to work against a redesigned site that is scheduled to go live tomorrow. 

Currently only dev/stage have the redesign. This tweak should [hopefully] get the build green on `dev` and `stage` jobs.
