### PR TITLE
Fix failing test_edit_profile_change_display_name that expected a specif.ic username at the start of the test

### DIFF
--- a/pages/page.py
+++ b/pages/page.py
@@ -63,6 +63,17 @@ class Page(object):
         except (NoSuchElementException, ElementNotVisibleException):
             return False
 
+    def is_element_not_visible(self, *locator):
+        self.selenium.implicitly_wait(0)
+        try:
+            element = self.selenium.find_element(*locator)
+            return not element.is_displayed()
+        except NoSuchElementException:
+            return True
+        finally:
+            # set back to where you once belonged
+            self.selenium.implicitly_wait(self.testsetup.default_implicit_wait)
+
     def open(self, url_fragment):
         self.selenium.get(self.base_url + url_fragment)
         self.selenium.maximize_window()

--- a/pages/user.py
+++ b/pages/user.py
@@ -108,9 +108,9 @@ class EditProfile(Page):
         def click_save_my_changes(self):
             self._root_element.find_element(*self._save_locator).click()
             WebDriverWait(self.selenium, self.timeout).until(
-                lambda s: not self.is_element_visible(*self._modal_locator))
+                lambda s: self.is_element_not_visible(*self._modal_locator))
 
         def click_cancel(self):
             self._root_element.find_element(*self._cancel_locator).click()
             WebDriverWait(self.selenium, self.timeout).until(
-                lambda s: not self.is_element_visible(*self._modal_locator))
+                lambda s: self.is_element_not_visible(*self._modal_locator))

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -25,24 +25,25 @@ class TestProfilePage:
 
         start_page = StartPage(mozwebqa)
         home_page = start_page.login()
-        username = mozwebqa.credentials['default']['name']
+        current_username = home_page.username
+        new_username = mozwebqa.credentials['default']['name'] + str(cur_date_time)
+        print current_username
+        print new_username
         edit_page = home_page.click_profile()
         edit_page_modal = edit_page.click_edit_profile()
 
-        edit_page_modal.set_display_name(mozwebqa.
-            credentials['default']['name'] + str(cur_date_time))
+        edit_page_modal.set_display_name(new_username)
         edit_page_modal.click_cancel()
-        Assert.equal(home_page.username, username.upper())
+        Assert.equal(home_page.username, current_username)
 
         edit_page_modal = edit_page.click_edit_profile()
-        new_name = mozwebqa.credentials['default']['name'] + str(cur_date_time)
-        edit_page_modal.set_display_name(new_name)
+        edit_page_modal.set_display_name(new_username)
         edit_page_modal.click_save_my_changes()
-        Assert.equal(home_page.username, new_name.upper())
+        Assert.equal(home_page.username, new_username.upper())
 
         # revert changes
         edit_page_modal = edit_page.click_edit_profile()
-        edit_page_modal.set_display_name(username)
+        edit_page_modal.set_display_name(current_username)
         edit_page_modal.click_save_my_changes()
 
     @credentials
@@ -57,8 +58,8 @@ class TestProfilePage:
         edit_page_modal.click_save_my_changes()
         Assert.true(edit_page.is_website_visible())
         Assert.equal(edit_page.view_website, 'http://wiki.mozilla.com/',
-            "Failed because expected 'http://wiki.mozilla.com' but returned "
-             + edit_page.view_website)
+                     "Failed because expected 'http://wiki.mozilla.com' but returned "
+                     + edit_page.view_website)
 
         # verify user can leave website field empty
         edit_page_modal = edit_page.click_edit_profile()
@@ -66,7 +67,7 @@ class TestProfilePage:
         edit_page_modal.click_save_my_changes()
         edit_page_modal = edit_page.click_edit_profile()
         Assert.equal(edit_page_modal.website, '',
-            'Clearing the website field failed.')
+                     'Clearing the website field failed.')
 
     @credentials
     @nondestructive


### PR DESCRIPTION
Also sped up the test by adding a is_element_not_visible method to page.py

Note that test_edit_profile_change_display_name has been failing on staging [1] due to the default username for the user being changed (likely as a result of this test failing before). We could "fix" this by just updating the username for the user on staging, but it's a bad idea to have a test that depends on data being in a specific state before the test is run (data that we are not controlling via the test), so I think this fix should be implemented.

[1] http://selenium.qa.mtv2.mozilla.com:8080/job/affiliates.stage.saucelabs/1163/HTML_Report/
