### PR TITLE
Add wait for changing display name, change edit page inheritance

### DIFF
--- a/pages/base.py
+++ b/pages/base.py
@@ -84,6 +84,3 @@ class Base(Page):
         self.selenium.find_element(*self._leaderboard_link_locator).click()
         from pages.leaderboard import LeaderboardPage
         return LeaderboardPage(self.testsetup)
-
-    def wait_until_expected_user(self, user):
-            WebDriverWait(self.selenium, self.timeout).until(lambda s: self.username == user)

--- a/pages/user.py
+++ b/pages/user.py
@@ -6,6 +6,7 @@
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.common.exceptions import TimeoutException
 
 from pages.page import Page
 from pages.base import Base
@@ -62,6 +63,13 @@ class EditProfile(Base):
 
     def is_newsletter_form_visible(self):
         return self.is_element_visible(*self._newsletter_form_locator)
+
+    def get_expected_user(self, user):
+        try:
+            WebDriverWait(self.selenium, self.timeout).until(lambda s: self.username != user)
+        except TimeoutException:
+            pass
+        return self.username
 
     class EditProfileModal(Page):
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -39,8 +39,7 @@ class TestProfilePage:
         edit_page_modal = edit_page.click_edit_profile()
         edit_page_modal.set_display_name(new_username)
         edit_page_modal.click_save_my_changes()
-        edit_page.wait_until_expected_user(new_username.upper())
-        Assert.equal(edit_page.username, new_username.upper())
+        Assert.equal(edit_page.get_expected_user(new_username.upper()), new_username.upper())
 
         # revert changes
         edit_page_modal = edit_page.click_edit_profile()


### PR DESCRIPTION
This is to attempt to solve the intermittent failures on saucelabs jobs by adding a wait. It also fixes inconsistencies with which page model is used in checks as well as changes inheritance of edit page to inherit from base. @bobsilverberg r?
