### PR TITLE
update website edit test

### DIFF
--- a/pages/user.py
+++ b/pages/user.py
@@ -23,12 +23,6 @@ class EditProfile(Base):
     _milestones_section_locator = (By.ID, 'milestones')
     _newsletter_form_locator = (By.ID, 'newsletter-form')
 
-    @property
-    def view_website(self):
-        return str(self.selenium.find_element(*self._view_website_locator).text)
-
-    def is_website_visible(self):
-        return self.is_element_visible(*self._view_website_locator)
 
     def click_edit_profile(self):
         self.selenium.find_element(*self._edit_profile_locator).click()

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -48,20 +48,21 @@ class TestProfilePage:
 
     @credentials
     @destructive
-    @pytest.mark.xfail("'affiliates.allizom' in config.getvalue('base_url')",
-                       reason="Bug 1053713 - [stage] Updating profile website the second time does not show up on profile page")
     def test_edit_profile_set_website(self, mozwebqa):
         start_page = StartPage(mozwebqa)
         home_page = start_page.login()
         edit_page = home_page.click_profile()
         edit_page_modal = edit_page.click_edit_profile()
 
-        edit_page_modal.set_website('http://wiki.mozilla.com/')
+        url = 'http://wiki.mozilla.org/' + str(datetime.now())
+
+        edit_page_modal.set_website(url)
         edit_page_modal.click_save_my_changes()
-        Assert.true(edit_page.is_website_visible())
-        Assert.equal(edit_page.view_website, 'http://wiki.mozilla.com/',
-                     "Failed because expected 'http://wiki.mozilla.com' but returned "
-                     + edit_page.view_website)
+        edit_page_modal = edit_page.click_edit_profile()
+
+        Assert.equal(edit_page_modal.website, url,
+                     "Failed because expected " + url + " but returned "
+                     + edit_page_modal.website)
 
         # verify user can leave website field empty
         edit_page_modal = edit_page.click_edit_profile()


### PR DESCRIPTION
The logic has changed a small bit. Affiliates no longer makes the website url visible via the publicly accessible profile. For a user to verify that an update to their profile for the website url field has occurred, verification must occur in the `edit profile modal`.
- removed the old logic and page object bits
- added `datetime.now()` to the test to add variability as well as help with debugging a failed test
