### PR TITLE
Fixed Failing TravixCI build by  making the xvfb screen size larger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ env:
 
 notifications:
   email:
-    - joshua.moravec@gmail.com
+    - webqa-ci@mozilla.org


### PR DESCRIPTION
Hello,
This is a fix for issue [#105](https://github.com/mozilla/Affiliates-Tests/issues/105). I found that by starting xvfb with a larger screen size (1280x1024x16) the test passes.
