### PR TITLE
Changed edit profile modal cancel button locator

### DIFF
--- a/pages/user.py
+++ b/pages/user.py
@@ -97,7 +97,7 @@ class EditProfile(Base):
         _website_label_locator = (By.CSS_SELECTOR, '#modal label[for="id_website"]')
         _edit_website_locator = (By.CSS_SELECTOR, '#modal input#id_website')
         _save_locator = (By.CSS_SELECTOR, '.button.go')
-        _cancel_locator = (By.CSS_SELECTOR, '.button.close')
+        _cancel_locator = (By.CSS_SELECTOR, '.button.secondary.close')
 
         def __init__(self, testsetup):
             Page.__init__(self, testsetup)


### PR DESCRIPTION
Issue #116 seems to cause intermittent failures on affiliates.stage. The failure is caused by not finding the cancel button on the edit profile modal.

I'm not 100% sure this will fix the issue, but updating the locator was the best option I could think of.