### PR TITLE
Wait for user menu to finish animating

### DIFF
--- a/pages/base.py
+++ b/pages/base.py
@@ -24,6 +24,8 @@ class Base(Page):
     def _hover_user_menu(self):
         username = self.selenium.find_element(*self._username_locator)
         ActionChains(self.selenium).move_to_element(username).perform()
+        WebDriverWait(self.selenium, self.timeout).until(
+            lambda d: d.execute_script('return $(":animated").length == 0;'))
 
     @property
     def is_user_logged_in(self):


### PR DESCRIPTION
With Selenium 2.48 we're intermittently clicking another element. This waits for any jQuery animations to finish. It's not perfect as there's no consideration for the animation not yet started, but it's a very quick animation. Also this checks that all animations on the page are finished, not the specific element. I tested multiple times locally and am happy with these minor risks.

Pinging @mozilla/web-qa-apprentices and @bobsilverberg for review.